### PR TITLE
Run on modern macOS (WKWebView) + brightness option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ xcuserdata/*
 *.xcuserstate
 project.xcworkspace/
 xcuserdata/
+
+# Local build output
+/build/

--- a/ConfigureSheet.xib
+++ b/ConfigureSheet.xib
@@ -9,6 +9,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="GridClock">
             <connections>
                 <outlet property="configSheet" destination="QvC-M9-y7g" id="Neh-j4-32j"/>
+                <outlet property="brightnessSlider" destination="bg2-Sl-d01" id="bg2-Sl-o01"/>
                 <outlet property="screenDisplayOption" destination="osi-OU-YaU" id="iw1-KE-NYE"/>
             </connections>
         </customObject>
@@ -17,14 +18,14 @@
         <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g" userLabel="Panel" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="320" height="102"/>
+            <rect key="contentRect" x="196" y="240" width="320" height="140"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1418"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="102"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="140"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a1k-tn-KC1">
-                        <rect key="frame" x="20" y="64" width="60" height="17"/>
+                        <rect key="frame" x="20" y="102" width="78" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Show on:" id="jOB-rY-MKy">
                             <font key="font" metaFont="system"/>
@@ -33,7 +34,7 @@
                         </textFieldCell>
                     </textField>
                     <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="osi-OU-YaU">
-                        <rect key="frame" x="84" y="58" width="219" height="26"/>
+                        <rect key="frame" x="102" y="96" width="201" height="26"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <popUpButtonCell key="cell" type="push" title="Primary Display" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="z3J-9s-f75" id="oq1-VZ-McK">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -47,6 +48,23 @@
                             </menu>
                         </popUpButtonCell>
                     </popUpButton>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bg1-La-b01">
+                        <rect key="frame" x="20" y="63" width="78" height="17"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Brightness:" id="bg1-La-c01">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <slider verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bg2-Sl-d01">
+                        <rect key="frame" x="102" y="62" width="201" height="21"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <sliderCell key="cell" continuous="YES" state="on" alignment="left" minValue="5" maxValue="100" doubleValue="100" tickMarkPosition="above" sliderType="linear" id="bg2-Sl-c01"/>
+                        <connections>
+                            <action selector="brightnessChanged:" target="-2" id="bg2-Sl-a01"/>
+                        </connections>
+                    </slider>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Od-P9-lod">
                         <rect key="frame" x="225" y="13" width="81" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>

--- a/Grid Clock.xcodeproj/project.pbxproj
+++ b/Grid Clock.xcodeproj/project.pbxproj
@@ -105,7 +105,6 @@
 				3A40066318B53112005F43A6 /* Frameworks */,
 				3A40066418B53112005F43A6 /* Headers */,
 				3A40066518B53112005F43A6 /* Resources */,
-				3A40066618B53112005F43A6 /* Rez */,
 			);
 			buildRules = (
 			);
@@ -122,7 +121,7 @@
 		3A40065E18B53112005F43A6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 2600;
 				ORGANIZATIONNAME = chrstphrknwtn;
 				TargetAttributes = {
 					3A40066718B53112005F43A6 = {
@@ -158,16 +157,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXRezBuildPhase section */
-		3A40066618B53112005F43A6 /* Rez */ = {
-			isa = PBXRezBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXRezBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		3A40066218B53112005F43A6 /* Sources */ = {
@@ -216,7 +205,7 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = fast;
+				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -228,7 +217,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
@@ -267,7 +256,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = fast;
+				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -275,8 +264,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				ONLY_ACTIVE_ARCH = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -284,7 +273,7 @@
 		3A40068018B53113005F43A6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Info.plist;
@@ -298,7 +287,7 @@
 		3A40068118B53113005F43A6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Info.plist;

--- a/GridClock.h
+++ b/GridClock.h
@@ -5,5 +5,6 @@
 
 @property (nonatomic, strong) IBOutlet NSWindow *configSheet;
 @property (nonatomic, weak) IBOutlet NSPopUpButton *screenDisplayOption;
+@property (nonatomic, weak) IBOutlet NSSlider *brightnessSlider;
 
 @end

--- a/GridClock.h
+++ b/GridClock.h
@@ -1,8 +1,9 @@
 #import <ScreenSaver/ScreenSaver.h>
+#import <WebKit/WebKit.h>
 
-@interface GridClock : ScreenSaverView
-{
-    IBOutlet id configSheet;
-    IBOutlet id screenDisplayOption;
-}
+@interface GridClock : ScreenSaverView <WKNavigationDelegate>
+
+@property (nonatomic, strong) IBOutlet NSWindow *configSheet;
+@property (nonatomic, weak) IBOutlet NSPopUpButton *screenDisplayOption;
+
 @end

--- a/GridClock.m
+++ b/GridClock.m
@@ -2,6 +2,10 @@
 
 static NSString * const kModuleName = @"com.chrstphrknwtn.grid-clock";
 static NSString * const kScreenDisplayOptionKey = @"screenDisplayOption";
+static NSString * const kBrightnessKey = @"brightness";
+
+static const NSInteger kMinBrightness = 5;
+static const NSInteger kMaxBrightness = 100;
 
 typedef NS_ENUM(NSInteger, GridClockScreenDisplayOption) {
     GridClockScreenDisplayPrimary = 0,
@@ -11,6 +15,7 @@ typedef NS_ENUM(NSInteger, GridClockScreenDisplayOption) {
 
 @interface GridClock ()
 @property (nonatomic, strong) WKWebView *webView;
+@property (nonatomic, assign) NSInteger brightnessBeforeEditing;
 @end
 
 @implementation GridClock
@@ -23,7 +28,8 @@ typedef NS_ENUM(NSInteger, GridClockScreenDisplayOption) {
     if (!(self = [super initWithFrame:frame isPreview:isPreview])) return nil;
 
     [[GridClock defaults] registerDefaults:@{
-        kScreenDisplayOptionKey: @(GridClockScreenDisplayPrimary)
+        kScreenDisplayOptionKey: @(GridClockScreenDisplayPrimary),
+        kBrightnessKey: @(kMaxBrightness)
     }];
 
     // Black backing avoids a white flash before index.html paints.
@@ -77,6 +83,8 @@ typedef NS_ENUM(NSInteger, GridClockScreenDisplayOption) {
 - (BOOL)shouldDisplayOnCurrentScreen {
     if (self.isPreview) return YES;
 
+    // nil means the host put this window off-screen entirely (see readme, multi-display
+    // note); nothing is visible either way, so do not also hide the content.
     NSScreen *screen = self.window.screen;
     if (!screen) return YES;
 
@@ -90,6 +98,16 @@ typedef NS_ENUM(NSInteger, GridClockScreenDisplayOption) {
         default:
             return YES;
     }
+}
+
+#pragma mark - Brightness
+
+- (void)applyBrightness:(NSInteger)percent {
+    percent = MAX(kMinBrightness, MIN(kMaxBrightness, percent));
+    NSString *script = [NSString stringWithFormat:
+                        @"document.documentElement.style.setProperty('--brightness', '%.2f')",
+                        percent / (double)kMaxBrightness];
+    [self.webView evaluateJavaScript:script completionHandler:nil];
 }
 
 #pragma mark - ScreenSaverView
@@ -112,18 +130,29 @@ typedef NS_ENUM(NSInteger, GridClockScreenDisplayOption) {
         }
     }
 
-    [self.screenDisplayOption selectItemAtIndex:[[GridClock defaults] integerForKey:kScreenDisplayOptionKey]];
+    ScreenSaverDefaults *defaults = [GridClock defaults];
+    [self.screenDisplayOption selectItemAtIndex:[defaults integerForKey:kScreenDisplayOptionKey]];
+
+    self.brightnessBeforeEditing = [defaults integerForKey:kBrightnessKey];
+    self.brightnessSlider.integerValue = self.brightnessBeforeEditing;
 
     return _configSheet;
 }
 
+// Continuous, so the preview dims while the slider is dragged.
+- (IBAction)brightnessChanged:(id)sender {
+    [self applyBrightness:self.brightnessSlider.integerValue];
+}
+
 - (IBAction)cancelClick:(id)sender {
+    [self applyBrightness:self.brightnessBeforeEditing];
     [self closeConfigureSheet];
 }
 
 - (IBAction)okClick:(id)sender {
     ScreenSaverDefaults *defaults = [GridClock defaults];
     [defaults setInteger:self.screenDisplayOption.indexOfSelectedItem forKey:kScreenDisplayOptionKey];
+    [defaults setInteger:self.brightnessSlider.integerValue forKey:kBrightnessKey];
     [defaults synchronize];
 
     self.webView.hidden = !self.shouldDisplayOnCurrentScreen;
@@ -141,6 +170,10 @@ typedef NS_ENUM(NSInteger, GridClockScreenDisplayOption) {
 }
 
 #pragma mark - WKNavigationDelegate
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
+    [self applyBrightness:[[GridClock defaults] integerForKey:kBrightnessKey]];
+}
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
     NSLog(@"GridClock: navigation failed: %@", error);

--- a/GridClock.m
+++ b/GridClock.m
@@ -1,124 +1,169 @@
 #import "GridClock.h"
-#import <WebKit/WebKit.h>
+
+static NSString * const kModuleName = @"com.chrstphrknwtn.grid-clock";
+static NSString * const kScreenDisplayOptionKey = @"screenDisplayOption";
+
+typedef NS_ENUM(NSInteger, GridClockScreenDisplayOption) {
+    GridClockScreenDisplayPrimary = 0,
+    GridClockScreenDisplayMain = 1,
+    GridClockScreenDisplayAll = 2
+};
+
+@interface GridClock ()
+@property (nonatomic, strong) WKWebView *webView;
+@end
 
 @implementation GridClock
 
-static NSString * const gridClockModule = @"com.chrstphrknwtn.grid-clock";
++ (ScreenSaverDefaults *)defaults {
+    return [ScreenSaverDefaults defaultsForModuleWithName:kModuleName];
+}
 
-- (id)initWithFrame:(NSRect)frame isPreview:(BOOL)isPreview {
+- (instancetype)initWithFrame:(NSRect)frame isPreview:(BOOL)isPreview {
     if (!(self = [super initWithFrame:frame isPreview:isPreview])) return nil;
-    
-    // Preference Defaults
-    ScreenSaverDefaults *defaults;
-    defaults = [ScreenSaverDefaults defaultsForModuleWithName:gridClockModule];
-    
-    [defaults registerDefaults:[NSDictionary dictionaryWithObjectsAndKeys:
-        @"0", @"screenDisplayOption", // Default to show only on primary display
-        nil]];
-    
-    // Webview
-    NSURL* indexHTMLDocumentURL = [NSURL URLWithString:[[[NSURL fileURLWithPath:[[NSBundle bundleForClass:self.class].resourcePath stringByAppendingString:@"/Webview/index.html"] isDirectory:NO] description] stringByAppendingFormat:@"?screensaver=1%@", self.isPreview ? @"&is_preview=1" : @""]];
 
-    WebView* webView = [[WebView alloc] initWithFrame:NSMakeRect(0, 0, frame.size.width, frame.size.height)];
-    webView.drawsBackground = NO; // Avoids a "white flash" just before the index.html file has loaded
-    [webView.mainFrame loadRequest:[NSURLRequest requestWithURL:indexHTMLDocumentURL cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:30.0]];
-    
-    // Show on screens based on preferences
-    NSArray* screens = [NSScreen screens];
-    NSScreen* primaryScreen = [screens objectAtIndex:0];
-    
-    switch ([defaults integerForKey:@"screenDisplayOption"]) {
-        // Primary screen (System Preferences > Displays).
-        // The screen the menubar is shown on under 'arrangement'
-        case 0:
-            if ((primaryScreen.frame.origin.x == frame.origin.x) || isPreview) {
-                [self addSubview:webView];
-            }
-            break;
-        // Last Focussed Screen
-        // This _sometimes_ results in nothing being shown when previewing in system prefs.
-        case 1:
-            if (([NSScreen mainScreen].frame.origin.x == frame.origin.x) || isPreview) {
-                [self addSubview:webView];
-            }
-            break;
-        // All Screens
-        case 2:
-            [self addSubview:webView];
-            break;
-        default:
-            [self addSubview:webView];
-            break;
-    }
+    [[GridClock defaults] registerDefaults:@{
+        kScreenDisplayOptionKey: @(GridClockScreenDisplayPrimary)
+    }];
+
+    // Black backing avoids a white flash before index.html paints.
+    self.wantsLayer = YES;
+    self.layer.backgroundColor = NSColor.blackColor.CGColor;
+
+    self.animationTimeInterval = 1.0 / 30.0;
+
+    [self addSubview:self.webView];
 
     return self;
 }
 
+- (WKWebView *)webView {
+    if (_webView) return _webView;
+
+    WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
+    configuration.suppressesIncrementalRendering = YES;
+
+    _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration:configuration];
+    _webView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    _webView.navigationDelegate = self;
+    _webView.hidden = YES; // Revealed in -viewDidMoveToWindow once the screen is known.
+    if (@available(macOS 12.0, *)) {
+        _webView.underPageBackgroundColor = NSColor.blackColor;
+    }
+
+    NSURL *indexURL = [[NSBundle bundleForClass:self.class] URLForResource:@"index"
+                                                             withExtension:@"html"
+                                                              subdirectory:@"Webview"];
+    if (indexURL) {
+        [_webView loadFileURL:indexURL allowingReadAccessToURL:indexURL.URLByDeletingLastPathComponent];
+    } else {
+        NSLog(@"GridClock: Webview/index.html missing from bundle resources");
+    }
+
+    return _webView;
+}
+
+#pragma mark - Screen selection
+
+// macOS runs one screen saver instance per display, so the display choice has to be
+// resolved from the window's own screen rather than by comparing frame origins.
+- (void)viewDidMoveToWindow {
+    [super viewDidMoveToWindow];
+    if (self.window) {
+        self.webView.hidden = !self.shouldDisplayOnCurrentScreen;
+    }
+}
+
+- (BOOL)shouldDisplayOnCurrentScreen {
+    if (self.isPreview) return YES;
+
+    NSScreen *screen = self.window.screen;
+    if (!screen) return YES;
+
+    switch ([[GridClock defaults] integerForKey:kScreenDisplayOptionKey]) {
+        case GridClockScreenDisplayPrimary:
+            // The screen the menu bar lives on (System Settings > Displays > Arrangement).
+            return [screen isEqual:NSScreen.screens.firstObject];
+        case GridClockScreenDisplayMain:
+            return [screen isEqual:NSScreen.mainScreen];
+        case GridClockScreenDisplayAll:
+        default:
+            return YES;
+    }
+}
+
 #pragma mark - ScreenSaverView
 
-- (void)animateOneFrame { [self stopAnimation]; }
+// The clock ticks itself from JavaScript; nothing to draw per frame.
+- (void)animateOneFrame {}
 
-#pragma mark - Config
-// http://cocoadevcentral.com/articles/000088.php
+#pragma mark - Configure sheet
 
 - (BOOL)hasConfigureSheet { return YES; }
 
-- (NSWindow *)configureSheet
-{
-    ScreenSaverDefaults *defaults;
-    defaults = [ScreenSaverDefaults defaultsForModuleWithName:gridClockModule];
-    
-    if (!configSheet)
-    {
-        if (![NSBundle loadNibNamed:@"ConfigureSheet" owner:self])
-        {
-            NSLog( @"Failed to load configure sheet." );
+- (NSWindow *)configureSheet {
+    if (!_configSheet) {
+        // +[NSBundle loadNibNamed:owner:] looks in the *host app* bundle, which for a
+        // screen saver is System Settings, not the .saver. Load from our own bundle.
+        NSBundle *bundle = [NSBundle bundleForClass:self.class];
+        if (![bundle loadNibNamed:@"ConfigureSheet" owner:self topLevelObjects:nil]) {
+            NSLog(@"GridClock: failed to load ConfigureSheet.xib");
+            return nil;
         }
     }
-    
-    [screenDisplayOption selectItemAtIndex:[defaults integerForKey:@"screenDisplayOption"]];
 
-    return configSheet;
+    [self.screenDisplayOption selectItemAtIndex:[[GridClock defaults] integerForKey:kScreenDisplayOptionKey]];
+
+    return _configSheet;
 }
 
-- (IBAction)cancelClick:(id)sender
-{
-    [[NSApplication sharedApplication] endSheet:configSheet];
+- (IBAction)cancelClick:(id)sender {
+    [self closeConfigureSheet];
 }
 
-- (IBAction) okClick: (id)sender
-{
-    ScreenSaverDefaults *defaults;
-    defaults = [ScreenSaverDefaults defaultsForModuleWithName:gridClockModule];
-    
-    // Update our defaults
-    [defaults setInteger:[screenDisplayOption indexOfSelectedItem]
-               forKey:@"screenDisplayOption"];
-    
-    // Save the settings to disk
+- (IBAction)okClick:(id)sender {
+    ScreenSaverDefaults *defaults = [GridClock defaults];
+    [defaults setInteger:self.screenDisplayOption.indexOfSelectedItem forKey:kScreenDisplayOptionKey];
     [defaults synchronize];
-    
-    // Close the sheet
-    [[NSApplication sharedApplication] endSheet:configSheet];
+
+    self.webView.hidden = !self.shouldDisplayOnCurrentScreen;
+
+    [self closeConfigureSheet];
 }
 
-#pragma mark - WebFrameLoadDelegate
-
-- (void)webView:(WebView *)sender didFailLoadWithError:(NSError *)error forFrame:(WebFrame *)frame {
-    NSLog(@"%@ error=%@", NSStringFromSelector(_cmd), error);
+- (void)closeConfigureSheet {
+    NSWindow *parent = _configSheet.sheetParent;
+    if (parent) {
+        [parent endSheet:_configSheet];
+    } else {
+        [_configSheet close];
+    }
 }
 
-#pragma mark Focus Overrides
+#pragma mark - WKNavigationDelegate
 
-- (NSView *)hitTest:(NSPoint)aPoint {return self;}
-//- (void)keyDown:(NSEvent *)theEvent {return;}
-//- (void)keyUp:(NSEvent *)theEvent {return;}
-- (void)mouseDown:(NSEvent *)theEvent {return;}
-- (void)mouseUp:(NSEvent *)theEvent {return;}
-- (void)mouseDragged:(NSEvent *)theEvent {return;}
-- (void)mouseEntered:(NSEvent *)theEvent {return;}
-- (void)mouseExited:(NSEvent *)theEvent {return;}
-- (BOOL)acceptsFirstResponder {return YES;}
-- (BOOL)resignFirstResponder {return NO;}
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    NSLog(@"GridClock: navigation failed: %@", error);
+}
+
+- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {
+    NSLog(@"GridClock: provisional navigation failed: %@", error);
+}
+
+- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView {
+    NSLog(@"GridClock: web content process terminated, reloading");
+    [webView reload];
+}
+
+#pragma mark - Input passthrough
+
+- (NSView *)hitTest:(NSPoint)aPoint { return self; }
+- (void)mouseDown:(NSEvent *)event {}
+- (void)mouseUp:(NSEvent *)event {}
+- (void)mouseDragged:(NSEvent *)event {}
+- (void)mouseEntered:(NSEvent *)event {}
+- (void)mouseExited:(NSEvent *)event {}
+- (BOOL)acceptsFirstResponder { return YES; }
+- (BOOL)resignFirstResponder { return NO; }
 
 @end

--- a/Info.plist
+++ b/Info.plist
@@ -11,17 +11,17 @@
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
-	<string>0.0.5</string>
+	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.5</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.5</string>
+	<string>1.0.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2018 Christopher Newton. All rights reserved.</string>
 	<key>NSPrincipalClass</key>

--- a/Webview/index.css
+++ b/Webview/index.css
@@ -20,6 +20,8 @@ clock {
   height: 92vw;
   max-width: 92vh;
   max-height: 92vh;
+  /* --brightness is set from the screen saver's Options sheet. */
+  opacity: var(--brightness, 1);
 }
 
 glyph {

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,18 @@ This fork updates the 2018 original to run on current macOS (tested on macOS 26.
 - Fixed the configure sheet: the nib is now loaded from the saver's own bundle (`+[NSBundle loadNibNamed:owner:]` looked in the host app), and the sheet is dismissed via `-[NSWindow endSheet:]` instead of the long-removed `NSApplication` equivalent.
 - Display selection is resolved from the window's own `NSScreen` instead of comparing frame origins, which no longer works now that macOS runs one saver instance per display.
 - Deployment target raised to macOS 11, ad-hoc code signing enabled, Carbon `Rez` build phase removed.
+- Added a **Brightness** slider (5-100%) in Options, for leaving the clock up overnight.
+
+## Known issue: displays stacked vertically
+`legacyScreenSaver` hands each saver window a frame whose origin is in CoreGraphics
+coordinates (y grows downward from the top-left of the primary display) while AppKit
+reads it as y-up. Displays arranged side by side are unaffected because their origin
+is y=0 either way, but a display placed above or below the primary gets a window in
+empty space: `window.screen` is `nil` and that display shows the system background
+instead of the saver. A saver bundle cannot correct this - it runs in an app extension
+whose window frame is owned by the host process, so `-[NSWindow setFrame:]` and
+`-setFrameOrigin:` are both ignored. Arranging the displays side by side in
+System Settings > Displays > Arrangement avoids it.
 
 The build is arm64-only by default (Xcode 26's standard architectures). For a universal binary, set `ARCHS = "arm64 x86_64"`.
 

--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,8 @@ Then pick **Grid Clock** in System Settings > Screen Saver > Other.
 
 Prebuilt `.saver` from upstream: [0.0.5](https://github.com/chrstphrknwtn/grid-clock-screensaver/releases/download/0.0.5/Grid.Clock.0.0.5.saver.zip) (does not run on modern macOS).
 
-## Fork notes
-This fork updates the 2018 original to run on current macOS (tested on macOS 26.6.2 Tahoe, Xcode 26.6, Apple Silicon):
+## macOS 26 notes
+Brought up to date for current macOS (tested on macOS 26.6.2 Tahoe, Xcode 26.6, Apple Silicon):
 
 - Replaced the removed legacy `WebView` with `WKWebView`, loading the bundled page via `-loadFileURL:allowingReadAccessToURL:`.
 - Fixed the configure sheet: the nib is now loaded from the saver's own bundle (`+[NSBundle loadNibNamed:owner:]` looked in the host app), and the sheet is dismissed via `-[NSWindow endSheet:]` instead of the long-removed `NSApplication` equivalent.

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,26 @@ Grid clock macOS screensaver
 ![Grid Clock Screenshot](GridClock.png)
 
 ## Install
-Download [`Grid Clock.saver`](https://github.com/chrstphrknwtn/grid-clock-screensaver/releases/download/0.0.5/Grid.Clock.0.0.5.saver.zip)
+Build it yourself (requires Xcode):
+
+```
+xcodebuild -project "Grid Clock.xcodeproj" -scheme "Grid Clock" -configuration Release -derivedDataPath ./build
+cp -R "build/Build/Products/Release/Grid Clock.saver" ~/Library/Screen\ Savers/
+```
+
+Then pick **Grid Clock** in System Settings > Screen Saver > Other.
+
+Prebuilt `.saver` from upstream: [0.0.5](https://github.com/chrstphrknwtn/grid-clock-screensaver/releases/download/0.0.5/Grid.Clock.0.0.5.saver.zip) (does not run on modern macOS).
+
+## Fork notes
+This fork updates the 2018 original to run on current macOS (tested on macOS 26.6.2 Tahoe, Xcode 26.6, Apple Silicon):
+
+- Replaced the removed legacy `WebView` with `WKWebView`, loading the bundled page via `-loadFileURL:allowingReadAccessToURL:`.
+- Fixed the configure sheet: the nib is now loaded from the saver's own bundle (`+[NSBundle loadNibNamed:owner:]` looked in the host app), and the sheet is dismissed via `-[NSWindow endSheet:]` instead of the long-removed `NSApplication` equivalent.
+- Display selection is resolved from the window's own `NSScreen` instead of comparing frame origins, which no longer works now that macOS runs one saver instance per display.
+- Deployment target raised to macOS 11, ad-hoc code signing enabled, Carbon `Rez` build phase removed.
+
+The build is arm64-only by default (Xcode 26's standard architectures). For a universal binary, set `ARCHS = "arm64 x86_64"`.
 
 ## Related
 - [Epoch Flip Clock Screensaver](https://github.com/chrstphrknwtn/epoch-flip-clock-screensaver)


### PR DESCRIPTION
The 2018 build no longer runs on current macOS. This gets it working again, tested on macOS 26.6.2 (Tahoe) with Xcode 26.6 on Apple Silicon.

### What was broken

- **Legacy `WebView` is gone.** Replaced with `WKWebView`, loading the bundled page through `-loadFileURL:allowingReadAccessToURL:` so the sandboxed screen saver host can read it. The `?screensaver=1` query string is dropped — `loadFileURL:` rejects it and nothing in `index.js` read it.
- **The configure sheet never loaded.** `+[NSBundle loadNibNamed:owner:]` searches the *host app* bundle, which for a screen saver is System Settings, not the `.saver`. Now loaded from `[NSBundle bundleForClass:]`.
- **`-[NSApplication endSheet:]` was removed.** The sheet is dismissed via its `sheetParent`.
- **Display selection compared `NSScreen` frame origins against the view frame.** macOS now runs one saver instance per display, so the choice is resolved from `self.window.screen` in `-viewDidMoveToWindow`.
- **`-animateOneFrame` called `-stopAnimation` on itself.** The clock ticks from JavaScript, so it is now a no-op.
- White flash on load replaced with a black backing layer plus `underPageBackgroundColor`.

Build settings: deployment target 10.11 → 11.0, ad-hoc code signing (required on Apple Silicon), removed the unsupported Carbon `Rez` phase, `-Ofast` → `-Os`. Builds with no warnings under Xcode 26.6.

### Also added

A **Brightness** slider (5–100%) in Options, implemented as `opacity` on the `clock` element driven by a `--brightness` custom property, so lit and unlit glyphs dim together toward the black background. Continuous, so the preview dims while dragging; Cancel restores the saved value.

### One thing I could not fix

On a multi-display setup, `legacyScreenSaver` hands each saver window a frame whose origin is in CoreGraphics coordinates (y grows downward from the top-left of the primary display) while AppKit reads it as y-up. Displays arranged side by side are unaffected — their origin is y=0 either way — but a display stacked above or below the primary gets a window in empty space:

```
window frame handed to the saver   {{-305, -1440}, {3440, 1440}}
where that display actually is     {{-305,  1692}, {3440, 1440}}
```

`window.screen` is `nil` in that case and the display shows the system background instead of the saver. A saver bundle cannot correct it: it runs inside an app extension whose window belongs to the host process, so `-[NSWindow setFrame:]` and `-setFrameOrigin:` are both silently ignored. Documented in the readme with the side-by-side workaround.

### Testing

Verified by loading the built bundle and driving it directly: principal class instantiates, the configure sheet nib loads, the `WKWebView` loads the bundled page, and the JavaScript lights the expected glyphs for the current time. The brightness slider was checked end to end (slider at 30% → computed `clock` opacity `0.3`). Also run as the live screen saver via `ScreenSaverEngine` and captured from both displays, which is how the multi-display bug above was found.

Single-display and side-by-side arrangements are the configurations I could confirm working; I only have one machine to test on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
